### PR TITLE
Switch to BioPerl 1.6.924

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_install:
     - git clone --branch master --depth 1 https://github.com/Ensembl/ensembl-funcgen.git
     - git clone --branch master --depth 1 https://github.com/Ensembl/ensembl-hive.git
     - git clone --branch master --depth 1 https://github.com/Ensembl/ensembl-io.git
-    - git clone -b bioperl-release-1-6-1 --depth 1 https://github.com/bioperl/bioperl-live.git
+    - git clone -b release-1-6-924 --depth 1 https://github.com/bioperl/bioperl-live.git
 
 
 install:


### PR DESCRIPTION
The minimum recommend BioPerl is now 1.6.924. The maximum recommended BioPerl is also 1.6.924